### PR TITLE
feat: add a relative path and hide projectid from url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ server {
     ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
     server_name  localhost;
 
+		rewrite ^/login/(.*)$ /$1 last;
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html;

--- a/package.json
+++ b/package.json
@@ -98,5 +98,6 @@
 		"dependencies": {
 			"typescript": "<5.1.4"
 		}
-	}
+	},
+	"homepage": "login"
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import App from './App';
+import packageJson from '../package.json';
 
 jest.mock('@descope/react-sdk', () => ({
 	...jest.requireActual('@descope/react-sdk'),
@@ -17,7 +18,9 @@ describe('App component', () => {
 	test('displays Welcome component when projectId is missing', async () => {
 		Object.defineProperty(window, 'location', {
 			value: {
-				pathname: '/invalid-project-id'
+				pathname: `/${packageJson.homepage}/invalid-project-id`,
+				replace: jest.fn(),
+				href: { replace: jest.fn() }
 			},
 			writable: true // possibility to override
 		});
@@ -38,7 +41,9 @@ describe('App component', () => {
 	test('displays Descope component when projectId is valid and part of the location', async () => {
 		Object.defineProperty(window, 'location', {
 			value: {
-				pathname: '/P2Qbs5l8F1kD1g2inbBktiCDummy'
+				pathname: `/${packageJson.homepage}/P2Qbs5l8F1kD1g2inbBktiCDummy`,
+				replace: jest.fn(),
+				href: { replace: jest.fn() }
 			},
 			writable: true // possibility to override
 		});
@@ -49,7 +54,9 @@ describe('App component', () => {
 	test('displays Descope component when projectId is invalid and part of the location', async () => {
 		Object.defineProperty(window, 'location', {
 			value: {
-				pathname: '/P2Qbs5l8F1kD1g2inbBktiCDumm'
+				pathname: `/${packageJson.homepage}/P2Qbs5l8F1kD1g2inbBktiCDumm`,
+				replace: jest.fn(),
+				href: { replace: jest.fn() }
 			},
 			writable: true // possibility to override
 		});
@@ -69,15 +76,51 @@ describe('App component', () => {
 		expect(screen.getByTestId('welcome-component')).toBeInTheDocument();
 	});
 
+	test('that the welcome component shows the homepage path', async () => {
+		render(<App />);
+		expect(screen.getByTestId('welcome-component')).toHaveTextContent(
+			`/${packageJson.homepage}/`
+		);
+	});
+
 	test('displays Descope component when projectId is valid and part of the location and env', async () => {
 		process.env.DESCOPE_PROJECT_ID = 'P2Qbs5l8F1kD1g2inbBktiCDummk';
 		Object.defineProperty(window, 'location', {
 			value: {
-				pathname: '/P2Qbs5l8F1kD1g2inbBktiCDummy'
+				pathname: `/${packageJson.homepage}/P2Qbs5l8F1kD1g2inbBktiCDummy`,
+				replace: jest.fn(),
+				href: { replace: jest.fn() }
 			},
 			writable: true // possibility to override
 		});
 		render(<App />);
 		expect(screen.getByTestId('descope-component')).toBeInTheDocument();
+	});
+
+	test('that the projectid is removed from the url', async () => {
+		Object.defineProperty(window, 'location', {
+			value: {
+				pathname: `/${packageJson.homepage}/P2Qbs5l8F1kD1g2inbBktiCDummy`,
+				replace: jest.fn(),
+				href: {
+					replace: jest.fn((searchValue: string, replaceValue: string) =>
+						`/${packageJson.homepage}/P2Qbs5l8F1kD1g2inbBktiCDummy`.replace(
+							searchValue,
+							replaceValue
+						)
+					)
+				}
+			},
+			writable: true // possibility to override
+		});
+		render(<App />);
+		expect(screen.getByTestId('descope-component')).toBeInTheDocument();
+		expect(window.location.href.replace).toHaveBeenCalledWith(
+			'P2Qbs5l8F1kD1g2inbBktiCDummy',
+			''
+		);
+		expect(window.location.replace).toHaveBeenCalledWith(
+			`/${packageJson.homepage}/`
+		);
 	});
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,34 +1,60 @@
 import '@testing-library/jest-dom';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import App from './App';
 import packageJson from '../package.json';
 
+const mockDescope = jest.fn();
+const mockAuthProvider = jest.fn();
+
 jest.mock('@descope/react-sdk', () => ({
 	...jest.requireActual('@descope/react-sdk'),
-	Descope: jest.fn(() => <div />)
+	Descope: (props: unknown) => {
+		mockDescope(props);
+		return <div />;
+	},
+	AuthProvider: (props: PropsWithChildren<{ [key: string]: string }>) => {
+		const { children } = props;
+		mockAuthProvider(props);
+		return <div>{children}</div>;
+	}
 }));
 
+const validProjectId = 'P2Sn0gttY5sY4Zu6WDGAAEJ4VTrv';
+const invalidProjectId = 'P2Qbs5l8F1kD1g2inbBktiCDumm';
+const baseUrl = 'https://api.descope.test';
+const flowId = 'test';
+const debug = true;
+
 describe('App component', () => {
+	beforeAll(() => {
+		Object.defineProperty(window, 'location', {
+			value: {
+				href: 'http://localhost:3000/',
+				pathname: '',
+				origin: 'http://localhost:3000',
+				replace: jest.fn((href: string) => {
+					window.location.href = href;
+				})
+			},
+			writable: true
+		});
+		Object.defineProperty(navigator, 'clipboard', {
+			value: {
+				writeText: jest.fn()
+			}
+		});
+	});
+
 	beforeEach(() => {
 		jest.resetModules();
 		process.env.DESCOPE_PROJECT_ID = '';
+		window.location.pathname = '';
+		window.localStorage.clear();
 	});
 
 	test('displays Welcome component when projectId is missing', async () => {
-		Object.defineProperty(window, 'location', {
-			value: {
-				pathname: `/${packageJson.homepage}/invalid-project-id`,
-				replace: jest.fn(),
-				href: { replace: jest.fn() }
-			},
-			writable: true // possibility to override
-		});
-		Object.assign(navigator, {
-			clipboard: {
-				writeText: () => undefined
-			}
-		});
+		window.location.pathname = `/${packageJson.homepage}/${invalidProjectId}`;
 
 		render(<App />);
 		expect(screen.getByTestId('welcome-component')).toBeInTheDocument();
@@ -36,91 +62,81 @@ describe('App component', () => {
 		expect(screen.getByTestId('welcome-copy-icon')).toBeInTheDocument();
 		fireEvent.click(screen.getByTestId('welcome-copy-component'));
 		await screen.findByTestId('welcome-copied-icon');
-	});
-
-	test('displays Descope component when projectId is valid and part of the location', async () => {
-		Object.defineProperty(window, 'location', {
-			value: {
-				pathname: `/${packageJson.homepage}/P2Qbs5l8F1kD1g2inbBktiCDummy`,
-				replace: jest.fn(),
-				href: { replace: jest.fn() }
-			},
-			writable: true // possibility to override
-		});
-		render(<App />);
-		expect(screen.getByTestId('descope-component')).toBeInTheDocument();
-	});
-
-	test('displays Descope component when projectId is invalid and part of the location', async () => {
-		Object.defineProperty(window, 'location', {
-			value: {
-				pathname: `/${packageJson.homepage}/P2Qbs5l8F1kD1g2inbBktiCDumm`,
-				replace: jest.fn(),
-				href: { replace: jest.fn() }
-			},
-			writable: true // possibility to override
-		});
-		render(<App />);
-		expect(screen.getByTestId('welcome-component')).toBeInTheDocument();
-	});
-
-	test('displays Descope component when projectId is valid and as an env var', async () => {
-		process.env.DESCOPE_PROJECT_ID = 'P2Qbs5l8F1kD1g2inbBktiCDummy';
-		render(<App />);
-		expect(screen.getByTestId('descope-component')).toBeInTheDocument();
-	});
-
-	test('displays Descope component when projectId is invalid and as an env var', async () => {
-		process.env.DESCOPE_PROJECT_ID = 'P2Qbs5l8F1kD1g2inbBktiCDumm';
-		render(<App />);
-		expect(screen.getByTestId('welcome-component')).toBeInTheDocument();
-	});
-
-	test('that the welcome component shows the homepage path', async () => {
-		render(<App />);
 		expect(screen.getByTestId('welcome-component')).toHaveTextContent(
 			`/${packageJson.homepage}/`
 		);
 	});
 
+	test('displays Descope component when projectId is valid and part of the location', async () => {
+		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
+		render(<App />);
+		expect(screen.getByTestId('descope-component')).toBeInTheDocument();
+	});
+
+	test('displays welcome component when projectId is invalid and part of the location', async () => {
+		window.location.pathname = `/${packageJson.homepage}/${invalidProjectId}`;
+		render(<App />);
+		expect(screen.getByTestId('welcome-component')).toBeInTheDocument();
+	});
+
+	test('displays Descope component when projectId is valid and as an env var', async () => {
+		process.env.DESCOPE_PROJECT_ID = validProjectId;
+		render(<App />);
+		expect(screen.getByTestId('descope-component')).toBeInTheDocument();
+	});
+
+	test('displays welcome component when projectId is invalid and as an env var', async () => {
+		process.env.DESCOPE_PROJECT_ID = invalidProjectId;
+		render(<App />);
+		expect(screen.getByTestId('welcome-component')).toBeInTheDocument();
+	});
+
 	test('displays Descope component when projectId is valid and part of the location and env', async () => {
-		process.env.DESCOPE_PROJECT_ID = 'P2Qbs5l8F1kD1g2inbBktiCDummk';
-		Object.defineProperty(window, 'location', {
-			value: {
-				pathname: `/${packageJson.homepage}/P2Qbs5l8F1kD1g2inbBktiCDummy`,
-				replace: jest.fn(),
-				href: { replace: jest.fn() }
-			},
-			writable: true // possibility to override
-		});
+		process.env.DESCOPE_PROJECT_ID = validProjectId;
+		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
 		render(<App />);
 		expect(screen.getByTestId('descope-component')).toBeInTheDocument();
 	});
 
 	test('that the projectid is removed from the url', async () => {
-		Object.defineProperty(window, 'location', {
-			value: {
-				pathname: `/${packageJson.homepage}/P2Qbs5l8F1kD1g2inbBktiCDummy`,
-				replace: jest.fn(),
-				href: {
-					replace: jest.fn((searchValue: string, replaceValue: string) =>
-						`/${packageJson.homepage}/P2Qbs5l8F1kD1g2inbBktiCDummy`.replace(
-							searchValue,
-							replaceValue
-						)
-					)
-				}
-			},
-			writable: true // possibility to override
-		});
+		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
 		render(<App />);
 		expect(screen.getByTestId('descope-component')).toBeInTheDocument();
-		expect(window.location.href.replace).toHaveBeenCalledWith(
-			'P2Qbs5l8F1kD1g2inbBktiCDummy',
-			''
+		expect(window.location.pathname).toBe(`/${packageJson.homepage}/`);
+	});
+
+	test('that the baseUrl is the same as the origin', async () => {
+		Object.defineProperty(window.location, 'origin', {
+			value: baseUrl
+		});
+		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
+		render(<App />);
+		expect(mockAuthProvider).toHaveBeenCalledWith(
+			expect.objectContaining({ baseUrl })
 		);
-		expect(window.location.replace).toHaveBeenCalledWith(
-			`/${packageJson.homepage}/`
+	});
+
+	test('that the flow can be customized with env', async () => {
+		process.env.REACT_APP_DESCOPE_BASE_URL = baseUrl;
+		process.env.DESCOPE_FLOW_ID = flowId;
+		process.env.DESCOPE_FLOW_DEBUG = debug.toString();
+
+		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
+		render(<App />);
+		expect(mockAuthProvider).toHaveBeenCalledWith(
+			expect.objectContaining({ baseUrl })
+		);
+		expect(mockDescope).toHaveBeenCalledWith(
+			expect.objectContaining({ debug, flowId })
+		);
+	});
+
+	test('that the flow can be customized with search params', async () => {
+		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
+		window.location.search = `?debug=${debug}&flow=${flowId}`;
+		render(<App />);
+		expect(mockDescope).toHaveBeenCalledWith(
+			expect.objectContaining({ debug, flowId })
 		);
 	});
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,29 +8,26 @@ const projectRegex = /^P[a-zA-Z0-9]{27}$/;
 const App = () => {
 	const [error, setError] = useState(false);
 
-	const baseUrl = process.env.REACT_APP_DESCOPE_BASE_URL || '';
+	const baseUrl =
+		process.env.REACT_APP_DESCOPE_BASE_URL || window.location.origin;
 
 	let projectId = '';
 
 	// first, take project id from env
-	const envProjectId = process.env.DESCOPE_PROJECT_ID;
-	if (envProjectId && projectRegex.test(envProjectId)) {
-		projectId = envProjectId;
+	const envProjectId = projectRegex.exec(
+		process.env.DESCOPE_PROJECT_ID ?? ''
+	)?.[0];
+
+	// If exists in URI we will take it from the URI and save it in local storage
+	const pathnameProjectId = window.location.pathname?.split('/').at(-1) || '';
+	if (pathnameProjectId && projectRegex.test(pathnameProjectId)) {
+		projectId = pathnameProjectId;
+		window.localStorage.setItem('descope-project-id', projectId);
+		window.location.pathname = window.location.pathname.replace(projectId, '');
 	}
 
-	// If exists in URI we will take it from the URI
-	const pathnameProjectId = window.location.pathname?.split('/').at(-1) || '';
-	if (pathnameProjectId) {
-		if (projectRegex.test(pathnameProjectId)) {
-			projectId = pathnameProjectId;
-			window.localStorage.setItem('descope-project-id', projectId);
-			window.location.replace(window.location.href.replace(projectId, ''));
-		} else {
-			console.log(`Invalid Project ID: ${pathnameProjectId}`); // eslint-disable-line
-		}
-	} else {
-		projectId = window.localStorage.getItem('descope-project-id') || '';
-	}
+	projectId =
+		window.localStorage.getItem('descope-project-id') ?? envProjectId ?? '';
 
 	const urlParams = new URLSearchParams(window.location.search);
 
@@ -53,7 +50,7 @@ const App = () => {
 						/>
 					</div>
 				) : (
-					<Welcome />
+					<Welcome baseUrl={baseUrl} />
 				)}
 			</div>
 		</AuthProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,12 +18,16 @@ const App = () => {
 		process.env.DESCOPE_PROJECT_ID ?? ''
 	)?.[0];
 
-	// If exists in URI we will take it from the URI and save it in local storage
+	// If exists in URI save it in local storage
+	// and redirect to the same page without the project id in the URI
 	const pathnameProjectId = window.location.pathname?.split('/').at(-1) || '';
 	if (pathnameProjectId && projectRegex.test(pathnameProjectId)) {
-		projectId = pathnameProjectId;
-		window.localStorage.setItem('descope-project-id', projectId);
-		window.location.pathname = window.location.pathname.replace(projectId, '');
+		window.localStorage.setItem('descope-project-id', pathnameProjectId);
+		window.location.pathname = window.location.pathname.replace(
+			pathnameProjectId,
+			''
+		);
+		// execution will stop here and the page will reload
 	}
 
 	projectId =

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,9 +23,13 @@ const App = () => {
 	if (pathnameProjectId) {
 		if (projectRegex.test(pathnameProjectId)) {
 			projectId = pathnameProjectId;
+			window.localStorage.setItem('descope-project-id', projectId);
+			window.location.replace(window.location.href.replace(projectId, ''));
 		} else {
 			console.log(`Invalid Project ID: ${pathnameProjectId}`); // eslint-disable-line
 		}
+	} else {
+		projectId = window.localStorage.getItem('descope-project-id') || '';
 	}
 
 	const urlParams = new URLSearchParams(window.location.search);

--- a/src/components/Welcome.tsx
+++ b/src/components/Welcome.tsx
@@ -5,8 +5,9 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
 import packageJson from '../../package.json';
 
-const Welcome = () => {
-	const exampleText = `https://auth.descope.io/${packageJson.homepage}/PROJECT_ID`;
+const Welcome = (props: { baseUrl: string }) => {
+	const { baseUrl } = props;
+	const exampleText = `${baseUrl}/${packageJson.homepage}/PROJECT_ID`;
 
 	const [value, copy] = useCopyToClipboard();
 	const onCopy = useCallback(async () => {

--- a/src/components/Welcome.tsx
+++ b/src/components/Welcome.tsx
@@ -3,9 +3,10 @@ import React, { useCallback } from 'react';
 import { useCopyToClipboard } from 'usehooks-ts';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
+import packageJson from '../../package.json';
 
 const Welcome = () => {
-	const exampleText = `https://auth.descope.io/PROJECT_ID`;
+	const exampleText = `https://auth.descope.io/${packageJson.homepage}/PROJECT_ID`;
 
 	const [value, copy] = useCopyToClipboard();
 	const onCopy = useCallback(async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/login/:path*",
+			"destination": "/:path*"
+		}
+	]
+}


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/3211

## Description

Introduce a base path for the project as it will be served from `/login`
When a project id exists in the path, remove it from the URL and store locally for future reference

