### PR TITLE
Added Tenant ID Passthrough

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 DESCOPE_PROJECT_ID= # Your Descope Project ID
-DESCOPE_FLOW_ID="sign-up-or-in" # Your Descope flow ID
 DESCOPE_TENANT_ID= # Your Descope Tenant ID
+DESCOPE_FLOW_ID="sign-up-or-in" # Your Descope flow ID
 DESCOPE_FLOW_DEBUG= # Set to true in case you want to debug your flow
 REACT_APP_DESCOPE_BASE_URL= # Descope API base URL
 REACT_APP_USE_ORIGIN_BASE_URL= # Set in case you want to use the origin as

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 DESCOPE_PROJECT_ID= # Your Descope Project ID
 DESCOPE_FLOW_ID="sign-up-or-in" # Your Descope flow ID
+DESCOPE_TENANT_ID= # Your Descope Tenant ID
 DESCOPE_FLOW_DEBUG= # Set to true in case you want to debug your flow
 REACT_APP_DESCOPE_BASE_URL= # Descope API base URL
 REACT_APP_USE_ORIGIN_BASE_URL= # Set in case you want to use the origin as

--- a/README.md
+++ b/README.md
@@ -40,10 +40,17 @@ You can refer to either the [main documentation](https://docs.descope.com/custom
 - Descope's deployment: `https://auth.descope.io/<PROJECT_ID>`
 - Locally: `http://localhost:3000/<PROJECT_ID>?flow=sign-in&debug=true`
 
-`<PROJECT_ID>` as part of the URL path is required to use the desired Descope's `PROJECT_ID`  
-`flow` query parameter is optional. If none provided the default flow is `sign-up-or-in`  
-`tenant` query parameter is optional. You can input a **Tenant ID** or **Tenant Domain** to use with this query parameter (e.g. `tenant=descope.com, tenant=T2UjlUN1tJsRnrV3jnAkJ3WziaEq). If present, then you will be able to authenticate via SSO, without having to first specify an email with an input screen in your flow.
-`debug`query parameter is optional. If debug mode is needed use`debug=true`
+These are the different query parameters you can use:
+
+1. `<PROJECT_ID>` as part of the URL path is required to use the desired Descope's `PROJECT_ID`
+
+2. `flow` query parameter is optional. If none provided the default flow is `sign-up-or-in`
+
+3. `tenant` query parameter is optional. You can input a **Tenant ID** or **Tenant Domain** to use with this query parameter (e.g. `tenant=descope.com` or `tenant=T2UjlUN1tJsRnrV3jnAkJ3WziaEq`).
+
+> If present, then you will be able to authenticate via SSO, without having to first specify an email with an input screen in your flow.
+
+4. `debug`query parameter is optional. If debug mode is needed use`debug=true`
 
 **Using .env**
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can refer to either the [main documentation](https://docs.descope.com/custom
 `<PROJECT_ID>` as part of the URL path is required to use the desired Descope's `PROJECT_ID`  
 `flow` query parameter is optional. If none provided the default flow is `sign-up-or-in`  
 `debug` query parameter is optional. If debug mode is needed use `debug=true`
-`tenant` query parameter is optional. If present, then you will be able to authenticate via SSO, without having to first specify an email with an input screen in your flow.
+`tenant` query parameter is optional. You can input a **Tenant ID** or **Tenant Domain** to use with this query parameter (e.g. `tenant=descope.com, tenant=T2UjlUN1tJsRnrV3jnAkJ3WziaEq). If present, then you will be able to authenticate via SSO, without having to first specify an email with an input screen in your flow.
 
 **Using .env**
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You can refer to either the [main documentation](https://docs.descope.com/custom
 - [Auth0](https://docs.descope.com/knowledgebase/sso/auth0oidc)
 - [Cognito](https://docs.descope.com/knowledgebase/sso/cognitooidc)
 - [Firebase](https://www.descope.com/blog/post/passkeys-firebase-oidc)
+- [Salesforce](https://www.descope.com/blog/post/sso-auth-salesforce)
 
 ---
 
@@ -42,6 +43,7 @@ You can refer to either the [main documentation](https://docs.descope.com/custom
 `<PROJECT_ID>` as part of the URL path is required to use the desired Descope's `PROJECT_ID`  
 `flow` query parameter is optional. If none provided the default flow is `sign-up-or-in`  
 `debug` query parameter is optional. If debug mode is needed use `debug=true`
+`tenant` query parameter is optional. If present, then you will be able to authenticate via SSO, without having to first specify an email with an input screen in your flow.
 
 **Using .env**
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ You can refer to either the [main documentation](https://docs.descope.com/custom
 
 `<PROJECT_ID>` as part of the URL path is required to use the desired Descope's `PROJECT_ID`  
 `flow` query parameter is optional. If none provided the default flow is `sign-up-or-in`  
-`debug` query parameter is optional. If debug mode is needed use `debug=true`
 `tenant` query parameter is optional. You can input a **Tenant ID** or **Tenant Domain** to use with this query parameter (e.g. `tenant=descope.com, tenant=T2UjlUN1tJsRnrV3jnAkJ3WziaEq). If present, then you will be able to authenticate via SSO, without having to first specify an email with an input screen in your flow.
+`debug`query parameter is optional. If debug mode is needed use`debug=true`
 
 **Using .env**
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,8 +35,7 @@ const App = () => {
 		urlParams.get('debug') === 'true' ||
 		process.env.DESCOPE_FLOW_DEBUG === 'true';
 
-	const tenantId = 
-		urlParams.get('tenant') || null;
+	const tenantId = urlParams.get('tenant') || null;
 
 	return (
 		<AuthProvider projectId={projectId} baseUrl={baseUrl}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ const App = () => {
 		urlParams.get('debug') === 'true' ||
 		process.env.DESCOPE_FLOW_DEBUG === 'true';
 
-	const tenantId = urlParams.get('tenant') || null;
+	const tenantId = urlParams.get('tenant') || process.env.DESCOPE_TENANT_ID;
 
 	return (
 		<AuthProvider projectId={projectId} baseUrl={baseUrl}>
@@ -45,7 +45,7 @@ const App = () => {
 						<Descope
 							flowId={flowId}
 							debug={debug}
-							{...(tenantId ? { tenant: tenantId } : {})}
+							tenant={tenantId}
 							onError={() => setError(true)}
 						/>
 					</div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,9 @@ const App = () => {
 		urlParams.get('debug') === 'true' ||
 		process.env.DESCOPE_FLOW_DEBUG === 'true';
 
+	const tenantId = 
+		urlParams.get('tenant') || null;
+
 	return (
 		<AuthProvider projectId={projectId} baseUrl={baseUrl}>
 			<div className="app">
@@ -43,6 +46,7 @@ const App = () => {
 						<Descope
 							flowId={flowId}
 							debug={debug}
+							{...(tenantId ? { tenant: tenantId } : {})}
 							onError={() => setError(true)}
 						/>
 					</div>


### PR DESCRIPTION
## Related Issues

✅ Fixes https://github.com/descope/etc/issues/3948

## Description

This will allow you to pass in a Tenant ID, and use SSO associated with that tenant, without having to pass in an email with a screen in the flow.

## Screenshots

📺🔫 All of the UI influenced by this PR

## Must

- [ ] 📱 Responsiveness (mobile/XL resolutions)
- [X] 🧪 Tests
- [X] 📃 Documentation (if applicable)
