### PR TITLE
remove descope container border

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -26,7 +26,6 @@ body,
 .descope-container {
 	border-radius: 15px;
 	box-shadow: 0px 1px 50px 0px #b2b2b2;
-	padding: 4px 4px;
 	max-width: 400px;
 }
 


### PR DESCRIPTION
## Related Issues

✅ Fixes https://github.com/descope/etc/issues/4272

## Description
suggestion to fix the visible border on non white background

this means that white bg will look like the following (unless border was set to the container)
![image](https://github.com/descope/auth-hosting/assets/10514677/66c8f3ca-8c14-4a2b-887e-4c1ed226e31a)

or like this with color:
![image](https://github.com/descope/auth-hosting/assets/10514677/5b8e783a-67ef-468c-9adf-de7bfb502a09)

 