### PR TITLE
Revert default favicon url

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,9 +62,7 @@ const App = () => {
 		[]
 	);
 
-	const faviconUrl =
-		process.env.REACT_APP_FAVICON_URL ||
-		'https://static.descope.com/pages/{projectId}/v2-beta/{ssoAppId}/assets/favicon.ico';
+	const faviconUrl = process.env.REACT_APP_FAVICON_URL || '';
 
 	let ssoAppId = urlParams.get('sso_app_id') || '';
 	ssoAppId = ssoAppRegex.exec(ssoAppId)?.[0] || '';


### PR DESCRIPTION
## Related Issues

Related to https://github.com/descope/auth-hosting/pull/555/files

## Description

💬 Remove default value for favicon URL, equivalent to turning the feature off if no env var is defined
