### PR TITLE
Bump dynamic sdk to 1.0.175

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"dependencies": {
-		"@descope-int/react-dynamic-sdk": "1.0.146",
+		"@descope-int/react-dynamic-sdk": "1.0.175",
 		"@emotion/react": "11.11.3",
 		"@emotion/styled": "11.11.0",
 		"@mui/icons-material": "5.15.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,10 +1348,10 @@
     normalize-package-data "^3||^4||^5||^6"
     xmlbuilder2 "^3.0.2"
 
-"@descope-int/react-dynamic-sdk@1.0.146":
-  version "1.0.146"
-  resolved "https://registry.yarnpkg.com/@descope-int/react-dynamic-sdk/-/react-dynamic-sdk-1.0.146.tgz#487199d9ebfc71bd5f21498730d83c0245030c4c"
-  integrity sha512-ogkVyMq39xFLHDpNFQaocHLQNEOSPPuQF8j9zC3bmRq1jUF9Uw+Jp3qQV56KIg/2X969FFNTgc33Wi44Oi5UtA==
+"@descope-int/react-dynamic-sdk@1.0.175":
+  version "1.0.175"
+  resolved "https://registry.yarnpkg.com/@descope-int/react-dynamic-sdk/-/react-dynamic-sdk-1.0.175.tgz#ff959d65f1133f2e24dab8deb6e1e7c038f75480"
+  integrity sha512-vSpg6IBYjXRLvxqCVIsZOSamA0oXYLrPve03r4DXKQC+KJVZ1ZSvVD74XXe2ws8BFpG18n/p05fSiL85DZCH7g==
   dependencies:
     "@descope/react-sdk" "^1.0.14"
     element-internals-polyfill "^1.3.9"


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/5992

## Description

- Bump dynamic sdk to 1.0.175