### PR TITLE
fix: favicon

### DIFF
--- a/api/favicon.js
+++ b/api/favicon.js
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch';
-
 export default async function handler(req, res) {
 	const { url } = req.query;
 	const defaultFaviconUrl = process.env.DEFAULT_FAVICON_URL;


### PR DESCRIPTION
fixes an issue where `/api/favicon` failed to run due to missing dep, by using built in fetch api instead of external dep