### PR TITLE
Use relative path for content base url

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,10 @@ import App from './App';
 import { env } from './env';
 import Error from './Error';
 
-const contentBaseUrl = env.REACT_APP_CONTENT_BASE_URL;
+const contentBaseUrl = env.REACT_APP_CONTENT_BASE_URL?.startsWith('/')
+	? window.location.origin + env.REACT_APP_CONTENT_BASE_URL
+	: env.REACT_APP_CONTENT_BASE_URL;
+
 if (contentBaseUrl) {
 	localStorage.setItem('base.content.url', contentBaseUrl);
 }


### PR DESCRIPTION
This pull request includes a small but important change to the `src/index.tsx` file. The change ensures that the `contentBaseUrl` dynamically handles relative URLs by appending the current origin when the URL starts with a `/`. This prevents potential issues when using relative paths in different environments.