### PR TITLE
fix(caddy) - add cloudflare as trusted proxy in caddy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,6 +5,11 @@
 		output stdout
 		level info
 	}
+
+	trusted_proxies cloudflare {
+		interval 12h
+		timeout 15s
+	}
 }
 
 http://*:{$PORT:8080} {


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/10007

## Description

Adding CF as trusted proxy to make it work locally.

## Screenshots

📺🔫 All of the UI influenced by this PR

## Must

- [ ] 📱 Responsiveness (mobile/XL resolutions)
- [ ] 🧪 Tests
- [ ] 📃 Documentation (if applicable)
