### PR TITLE
feat: support CF tunnel / arbitrary `Host` header

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,6 @@
 {
+	http_port {$PORT:8080}
+	auto_https off
 	debug
 	log {
 		format console
@@ -7,7 +9,7 @@
 	}
 }
 
-http://*:{$PORT:8080} {
+http:// {
 	log
 	encode gzip
 


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/10007

Previously attempted in: https://github.com/descope/auth-hosting/pull/874

## Description

Get caddy to not look for the `Host` header or do any SSL, taking another approach. 

## Must

- [ ] 📱 Responsiveness (mobile/XL resolutions)
- [ ] 🧪 Tests
- [ ] 📃 Documentation (if applicable)
