### PR TITLE
fix(oidc): preserve OIDC session params across mid-flow page refreshes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import './App.css';
 import Done from './components/Done';
 import Welcome from './components/Welcome';
 import useOidcMfa from './hooks/useOidcMfa';
+import { clearOidcSession } from './utils/oidcSession';
 import { env } from './env';
 import { logger } from './utils/logger';
 import { projectRegex } from './shared/projectRegex';
@@ -273,6 +274,7 @@ const App = () => {
 		form,
 		client,
 		onSuccess: (e: CustomEvent<FlowJWTResponse>) => {
+			clearOidcSession();
 			if (flowId === 'saml-config' || flowId === 'sso-config') {
 				let search = window?.location.search;
 				if (search) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { env } from './env';
 import Error from './Error';
+import { initOidcSession } from './utils/oidcSession';
 
 const contentBaseUrl = env.REACT_APP_CONTENT_BASE_URL?.startsWith('/')
 	? window.location.origin + env.REACT_APP_CONTENT_BASE_URL
@@ -11,6 +12,10 @@ const contentBaseUrl = env.REACT_APP_CONTENT_BASE_URL?.startsWith('/')
 if (contentBaseUrl) {
 	localStorage.setItem('base.content.url', contentBaseUrl);
 }
+
+// Restore OIDC session params into the URL before React renders so that
+// App.tsx's useMemo sees the full context even after a mid-flow page refresh.
+initOidcSession();
 
 const root = ReactDOM.createRoot(
 	document.getElementById('root') as HTMLElement

--- a/src/utils/oidcSession.ts
+++ b/src/utils/oidcSession.ts
@@ -1,0 +1,80 @@
+const STORAGE_KEY = 'oidc_session_params';
+
+// Only exclude params that are transient app states and must not be replayed.
+// Everything else (including state_id, oidc_error_redirect_uri, dynamic_val,
+// and any future Descope OIDC params) is preserved so the SDK can fully
+// restore the OIDC session after a mid-flow page refresh.
+const PARAMS_BLOCKLIST = new Set(['done']);
+
+type StoredParams = Record<string, string>;
+
+const readParamsToStore = (urlParams: URLSearchParams): StoredParams => {
+	const result: StoredParams = {};
+	urlParams.forEach((value, key) => {
+		if (!PARAMS_BLOCKLIST.has(key)) result[key] = value;
+	});
+	return result;
+};
+
+/**
+ * Call once before React renders (e.g. in index.tsx).
+ *
+ * - If sso_app_id is present in the URL: persist all relevant params to
+ *   sessionStorage so a mid-flow refresh can recover them.
+ * - If sso_app_id is absent: attempt to restore persisted params into the URL
+ *   via replaceState so the React tree sees the full OIDC context from the
+ *   very first render.
+ */
+export const initOidcSession = (): void => {
+	const urlParams = new URLSearchParams(window.location.search);
+
+	if (urlParams.has('sso_app_id')) {
+		// Fresh OIDC context arrived — save it, overwriting any stale session.
+		try {
+			sessionStorage.setItem(
+				STORAGE_KEY,
+				JSON.stringify(readParamsToStore(urlParams))
+			);
+		} catch {
+			// sessionStorage unavailable; proceed without persistence.
+		}
+		return;
+	}
+
+	// No OIDC context in the current URL — try to recover from sessionStorage.
+	try {
+		const raw = sessionStorage.getItem(STORAGE_KEY);
+		if (!raw) return;
+
+		const stored = JSON.parse(raw) as StoredParams;
+		let changed = false;
+		Object.entries(stored).forEach(([key, value]) => {
+			if (!urlParams.has(key)) {
+				urlParams.set(key, value);
+				changed = true;
+			}
+		});
+
+		if (changed) {
+			window.history.replaceState(
+				{},
+				'',
+				`${window.location.pathname}?${urlParams.toString()}`
+			);
+		}
+	} catch {
+		// Malformed storage entry — leave URL as-is.
+	}
+};
+
+/**
+ * Call when the OIDC flow completes successfully so stale params don't
+ * persist into unrelated page visits within the same browser tab.
+ */
+export const clearOidcSession = (): void => {
+	try {
+		sessionStorage.removeItem(STORAGE_KEY);
+	} catch {
+		// ignore
+	}
+};


### PR DESCRIPTION
When a user refreshes the page mid-flow, all URL params (including state_id, sso_app_id, oidc_error_redirect_uri, etc.) are lost, causing the Descope SDK to start a new OIDC session with no redirect context. Without state_id in particular, the SDK cannot look up the original authorization request and onSuccessRedirectUrl is never produced.

Adds initOidcSession() called synchronously in index.tsx before React renders: saves all non-transient URL params to sessionStorage when sso_app_id is present, and restores them into the URL via replaceState on refresh so the SDK reconnects to the existing OIDC session. Calls clearOidcSession() in onSuccess to prevent stale params from leaking into unrelated visits within the same tab.

## Related Issues

related to https://github.com/descope/etc/issues/15556

## Description

💬 A few sentences describing the overall goals of the pull request's commits.

## Screenshots

📺🔫 All of the UI influenced by this PR

## Must

- [ ] 📱 Responsiveness (mobile/XL resolutions)
- [ ] 🧪 Tests
- [ ] 📃 Documentation (if applicable)
