### PR TITLE
[Bug] Auth-hosting vulnerabiliity libcurl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,10 @@ RUN caddy validate --config /etc/caddy/Caddyfile && \
     caddy fmt --overwrite /etc/caddy/Caddyfile
 
 # build the final image with the correct target architecture (dont specify target)
-# Caddy is based on gcr.io/distroless/static-debian12:nonroot which does not contain /bin/sh so can't us RUN command here!
 FROM ghcr.io/verity-org/caddy:2.11.4 AS production
+
+# Patch curl/libcurl (Alpine base ships 8.19.0-r0) — CVE fixed in 8.20.0-r0
+RUN apk add --no-cache --upgrade curl=8.20.0-r0 libcurl=8.20.0-r0
 
 ENV PORT=8080
 ENV WWW_ROOT=/www


### PR DESCRIPTION
[View workflow run](https://github.com/descope/shuni/actions/runs/30052772644)

Committed cleanly.

## Summary

**Caddy is already at the latest version** — no bump needed. The base image `ghcr.io/verity-org/caddy:2.11.4` is pinned to `2.11.4`, which I confirmed is:
- the newest `ghcr.io/verity-org/caddy` tag (available: 2.11.1–2.11.4), **and**
- the latest upstream `caddyserver/caddy` release (`v2.11.4`).

**curl/libcurl patched** — this fresh branch was cut from `main` without the earlier CVE fix, so I re-applied it:
```dockerfile
RUN apk add --no-cache --upgrade curl=8.20.0-r0 libcurl=8.20.0-r0
```
(also dropped the stale "distroless/no-shell" comment — the base is Alpine with a working shell).

**Verified end-to-end** by building the `production` stage:
- `curl-8.20.0-r0` + `libcurl-8.20.0-r0` installed ✅
- Caddy `v2.11.4` still runs ✅

Nothing else in the repo installs or versions Caddy, so the Dockerfile is the only surface. If you specifically wanted a Caddy version *newer than 2.11.4*, none exists yet upstream — 2.11.4 is current.

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*