### PR TITLE
fix(docker): drop leading caddy from CMD to match new base image entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ WORKDIR ${WWW_ROOT}
 COPY --from=builder --chown=1000:1000 /app/build ${WWW_ROOT}
 COPY --from=builder --chown=1000:1000 /app/package.json ${WWW_ROOT}
 ADD --chown=nonroot:nonroot Caddyfile /etc/caddy/Caddyfile
-CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]
+CMD ["run", "--config", "/etc/caddy/Caddyfile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,5 @@ WORKDIR ${WWW_ROOT}
 COPY --from=builder --chown=1000:1000 /app/build ${WWW_ROOT}
 COPY --from=builder --chown=1000:1000 /app/package.json ${WWW_ROOT}
 ADD --chown=nonroot:nonroot Caddyfile /etc/caddy/Caddyfile
+ENTRYPOINT ["caddy"]
 CMD ["run", "--config", "/etc/caddy/Caddyfile"]


### PR DESCRIPTION
## Problem

The Docker container started failing recently with:

```
Error: unknown command "caddy" for "caddy"
Run 'caddy --help' for usage.
```

## Root cause

#1890 swapped the production base image from `ghcr.io/verity-org/caddy:2.11.4-fips` to `verity.supply/caddy:2.11-fips`.

The new image sets `ENTRYPOINT ["caddy"]` (the official Caddy image convention); the old one did not. ENTRYPOINT and CMD concatenate, so with `CMD ["caddy", "run", ...]` the container actually ran `caddy caddy run --config ...`. Caddy's Cobra CLI reads the second `caddy` as a subcommand -> `unknown command "caddy" for "caddy"`.

## Fix

Drop the redundant leading `caddy` from CMD so entrypoint + args combine into `caddy run --config ...`, matching the official Caddy image pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)