### PR TITLE
feat: send_session_token query param to enable sendSessionToken on the flow

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -173,6 +173,28 @@ describe('App component', () => {
 		);
 	});
 
+	test('that send_session_token search param enables sendSessionToken', async () => {
+		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
+		window.location.search = `?flow=${flowId}&send_session_token=true`;
+		render(<App />);
+		await waitFor(() =>
+			expect(mockDescope).toHaveBeenCalledWith(
+				expect.objectContaining({ flowId, sendSessionToken: true })
+			)
+		);
+	});
+
+	test('that sendSessionToken is off by default', async () => {
+		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
+		window.location.search = `?flow=${flowId}`;
+		render(<App />);
+		await waitFor(() =>
+			expect(mockDescope).toHaveBeenCalledWith(
+				expect.objectContaining({ flowId, sendSessionToken: undefined })
+			)
+		);
+	});
+
 	test('sets the document title from the title search param', async () => {
 		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
 		window.location.search = `?title=My%20Custom%20Title`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,6 +219,14 @@ const App = () => {
 			? false
 			: undefined;
 
+	// opt-in: send the current session JWT on flow start/next requests, exposing
+	// its validated claims to the flow via the sessionJwtClaims context key
+	const sendSessionToken =
+		urlParams.get('send_session_token') === 'true' ||
+		env.DESCOPE_SEND_SESSION_TOKEN === 'true'
+			? true
+			: undefined;
+
 	const theme = (urlParams.get('theme') ||
 		env.DESCOPE_FLOW_THEME) as React.ComponentProps<typeof Descope>['theme'];
 
@@ -289,6 +297,7 @@ const App = () => {
 	const flowProps = {
 		flowId,
 		debug,
+		sendSessionToken,
 		locale,
 		tenant: tenantId,
 		theme,


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17811

## Related PRs
### Related PRs
- https://github.com/descope/descope-kotlin/pull/356
- https://github.com/descope/descope-swift/pull/155
- https://github.com/descope/descope-react-native/pull/184

## In a Nutshell
- New `send_session_token=true` query param (or `DESCOPE_SEND_SESSION_TOKEN` env), off by default
- Maps to the Descope component's `sendSessionToken` prop

## Description
When enabled, the flow web component sends the current session JWT on flow start/next requests, so a flow can check the validated session claims server side (for example whether the user already completed step-up) via the `sessionJwtClaims` flow context key. This is the opt-in surface for hosted flow pages - in particular for mobile apps, whose native SDKs make the session JWT available to opted-in components (companion PRs).

## Must
- [ ] Tests
- [ ] Documentation (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)