### PR TITLE
[PATCH - DO NOT MERGE] send_session_token on top of the deployed prod build

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -173,6 +173,28 @@ describe('App component', () => {
 		);
 	});
 
+	test('that send_session_token search param enables sendSessionToken', async () => {
+		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
+		window.location.search = `?flow=${flowId}&send_session_token=true`;
+		render(<App />);
+		await waitFor(() =>
+			expect(mockDescope).toHaveBeenCalledWith(
+				expect.objectContaining({ flowId, sendSessionToken: true })
+			)
+		);
+	});
+
+	test('that sendSessionToken is off by default', async () => {
+		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
+		window.location.search = `?flow=${flowId}`;
+		render(<App />);
+		await waitFor(() =>
+			expect(mockDescope).toHaveBeenCalledWith(
+				expect.objectContaining({ flowId, sendSessionToken: undefined })
+			)
+		);
+	});
+
 	test('sets the document title from the title search param', async () => {
 		window.location.pathname = `/${packageJson.homepage}/${validProjectId}`;
 		window.location.search = `?title=My%20Custom%20Title`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,6 +219,14 @@ const App = () => {
 			? false
 			: undefined;
 
+	// opt-in: send the current session JWT on flow start/next requests, exposing
+	// its validated claims to the flow via the sessionJwtClaims context key
+	const sendSessionToken =
+		urlParams.get('send_session_token') === 'true' ||
+		env.DESCOPE_SEND_SESSION_TOKEN === 'true'
+			? true
+			: undefined;
+
 	const theme = (urlParams.get('theme') ||
 		env.DESCOPE_FLOW_THEME) as React.ComponentProps<typeof Descope>['theme'];
 
@@ -289,6 +297,7 @@ const App = () => {
 	const flowProps = {
 		flowId,
 		debug,
+		sendSessionToken,
 		locale,
 		tenant: tenantId,
 		theme,


### PR DESCRIPTION
## Purpose

**Do not merge.** This PR exists only to produce a patch image for production. The change itself is already on `main` as #1924.

## What this is

Production currently serves `532e0523a6d5d930bb664d50b93ab22a53f5e4ab` (per `https://api.descope.com/login/version`), which predates #1924. This branch is that exact commit with #1924 cherry-picked on top and nothing else - the resulting tree is byte-identical to `0c8f85d` on `main`, so the image is "what prod runs today, plus the `send_session_token` query param".

Four unrelated dependency/CI bumps sit between the deployed commit and `main`; deliberately not included.

## Why a patch instead of a normal deploy

The `send_session_token` param is the last piece of a cross-repo feature - without it the hosted flow page never sets `send-session-token` on the web component, so the corresponding SDK work has no effect for hosted flows.

Related: https://github.com/descope/etc/issues/17811